### PR TITLE
Fix readme syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ npm install tilestrata-headers --save
 var headers = require('tilestrata-headers');
 
 server.layer('mylayer').route('tile.png')
-    .use(headers({'Cache-Control: max-age=3600'}));
+    .use(headers({'Cache-Control': 'max-age=3600'}));
 ```
 
 ## Contributing


### PR DESCRIPTION
The README example won't work. I tested the headers module with CORS headers and I was able to start tilestrata with the right array syntax:

``` javascript
.use(headers({
    'Access-Control-Allow-Origin': '*',
    'Access-Control-Request-Method': '*',
    'Access-Control-Allow-Methods': 'OPTION, HEAD, GET',
    'Access-Control-Allow-Headers': '*'
}))
```
